### PR TITLE
プログラミングページを子記事に分割

### DIFF
--- a/articles/create/programming/aquasync/index.html
+++ b/articles/create/programming/aquasync/index.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1,shrink-to-fit=no" />
+    <site-head title="AQUASYNC"></site-head>
+    <link rel="stylesheet" href="../../../../css/style.css" />
+  </head>
+  <body>
+    <site-header></site-header>
+
+    <div id="app">
+      <div class="memox memox--page">
+        <header>
+          <h1 class="title">AQUASYNC</h1>
+        </header>
+
+        <section class="section-group">
+          <section>
+            <h3>概要</h3>
+            <p>
+              「君の鼓動で、海は色づく。」をコンセプトに、歩数や睡眠データをミズクラゲの見た目や水槽の透明度に反映するヘルスケア系アクアリウムアプリです。
+            </p>
+            <p>
+              Flutter（iOS / Android）、ヘルスデータは HealthKit / Google Fit、Firebase
+              を想定した構成で開発しています。
+            </p>
+          </section>
+
+          <section>
+            <h3>リンク</h3>
+            <a
+              class="explicit-link"
+              href="https://github.com/iorn121/AQUASYNC"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <span class="explicit-link__title">iorn121/AQUASYNC</span>
+              <span class="explicit-link__url">https://github.com/iorn121/AQUASYNC</span>
+            </a>
+          </section>
+        </section>
+
+        <ul class="article-list">
+          <!-- kurage:child-links -->
+        </ul>
+      </div>
+    </div>
+
+    <script type="module" src="/site.js"></script>
+    <site-footer></site-footer>
+  </body>
+</html>

--- a/articles/create/programming/color-verse/index.html
+++ b/articles/create/programming/color-verse/index.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1,shrink-to-fit=no" />
+    <site-head title="ColorVerse（カラーバース）"></site-head>
+    <link rel="stylesheet" href="../../../../css/style.css" />
+  </head>
+  <body>
+    <site-header></site-header>
+
+    <div id="app">
+      <div class="memox memox--page">
+        <header>
+          <h1 class="title">ColorVerse（カラーバース）</h1>
+        </header>
+
+        <section class="section-group">
+          <section>
+            <h3>概要</h3>
+            <p>
+              色の学習・ツール・分析・創作をまとめた
+              PWA。「色彩をより親しみやすくする」ことを目指し、カラーピッカー、HEX/RGB/HSL
+              変換、画像の色調補正、JIS
+              色名参照、カメラ連携、色覚特性シミュレーションなどを提供します。
+            </p>
+            <p>React + Vite + TypeScript、Canvas / MediaDevices、i18next による多言語対応です。</p>
+          </section>
+
+          <section>
+            <h3>リンク</h3>
+            <a
+              class="explicit-link"
+              href="https://github.com/iorn121/color-verse"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <span class="explicit-link__title">iorn121/color-verse</span>
+              <span class="explicit-link__url">https://github.com/iorn121/color-verse</span>
+            </a>
+            <a
+              class="explicit-link link-item"
+              href="https://color-verse.vercel.app/"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <span class="explicit-link__title">デモ（Vercel）</span>
+              <span class="explicit-link__url">https://color-verse.vercel.app/</span>
+            </a>
+          </section>
+        </section>
+
+        <ul class="article-list">
+          <!-- kurage:child-links -->
+        </ul>
+      </div>
+    </div>
+
+    <script type="module" src="/site.js"></script>
+    <site-footer></site-footer>
+  </body>
+</html>

--- a/articles/create/programming/deai/index.html
+++ b/articles/create/programming/deai/index.html
@@ -1,0 +1,57 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1,shrink-to-fit=no" />
+    <site-head title="Deai（であい）"></site-head>
+    <link rel="stylesheet" href="../../../../css/style.css" />
+  </head>
+  <body>
+    <site-header></site-header>
+
+    <div id="app">
+      <div class="memox memox--page">
+        <header>
+          <h1 class="title">Deai（であい）</h1>
+        </header>
+
+        <section class="section-group">
+          <section>
+            <h3>概要</h3>
+            <p>
+              地図を、出会いの装置に。人気順ではなく「まだ会っていない」順で、近くの一館がきらめく発見マップです。有名なスポットほど大きく目立つ地図のルールを反転させ、まだ知られていない場所ほど明るく表示します。
+            </p>
+            <ul class="experience-list">
+              <li><strong>発見マップ:</strong> 出会いやすさで館を照らす</li>
+              <li><strong>発見スコア:</strong> 知名度の低さを前向きな指標に</li>
+              <li><strong>テーマで出会う:</strong> 常設展のジャンルから横断的に探す</li>
+            </ul>
+            <p>
+              現在は東京エリアのサンプルデータで動くプロトタイプ。React 18 + Vite で構築しています。
+            </p>
+          </section>
+
+          <section>
+            <h3>リンク</h3>
+            <a
+              class="explicit-link"
+              href="https://github.com/iorn121/deai"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <span class="explicit-link__title">iorn121/deai</span>
+              <span class="explicit-link__url">https://github.com/iorn121/deai</span>
+            </a>
+          </section>
+        </section>
+
+        <ul class="article-list">
+          <!-- kurage:child-links -->
+        </ul>
+      </div>
+    </div>
+
+    <script type="module" src="/site.js"></script>
+    <site-footer></site-footer>
+  </body>
+</html>

--- a/articles/create/programming/index.html
+++ b/articles/create/programming/index.html
@@ -17,6 +17,10 @@
         <section class="section-group">
           <section>
             <p>
+              メインで進めている個人プロジェクトのメモです。各リポジトリの詳細は子ページと GitHub の
+              README を正としています。
+            </p>
+            <p>
               <a
                 class="inline-link"
                 href="https://github.com/iorn121"
@@ -36,107 +40,18 @@
               <li><strong>3D:</strong> Unity</li>
             </ul>
           </section>
-
-          <section>
-            <h3>よむかも（Yomu-Kamo）</h3>
-            <p>
-              論文や本を「よむかも」とストックし、後から読み返すためのカジュアルな管理アプリ。 DOI
-              からの取り込み、ISBN・バーコード、AI 要約やタグ付けなどを想定。フロントは Next.js（App
-              Router）と TypeScript、バックエンドは Go、データは Supabase。デプロイは Vercel や
-              Cloud Run を想定した構成です。
-            </p>
-            <a
-              class="explicit-link"
-              href="https://github.com/iorn121/Yomu-Kamo"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <span class="explicit-link__title">iorn121/Yomu-Kamo</span>
-              <span class="explicit-link__url">https://github.com/iorn121/Yomu-Kamo</span>
-            </a>
-          </section>
-
-          <section>
-            <h3>AQUASYNC</h3>
-            <p>
-              「君の鼓動で、海は色づく。」をコンセプトに、歩数や睡眠データをミズクラゲの見た目や水槽の透明度に反映するヘルスケア系アクアリウムアプリ。Flutter（iOS
-              / Android）、ヘルスデータは HealthKit / Google Fit、Firebase を想定した README
-              構成です。
-            </p>
-            <a
-              class="explicit-link"
-              href="https://github.com/iorn121/AQUASYNC"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <span class="explicit-link__title">iorn121/AQUASYNC</span>
-              <span class="explicit-link__url">https://github.com/iorn121/AQUASYNC</span>
-            </a>
-          </section>
-
-          <section>
-            <h3>旅の栞（tabi-no-shiori）</h3>
-            <p>
-              Svelte + Vite
-              ベースのフロントエンド用リポジトリです。リポジトリ名のとおり旅の記録・しおりとして使う予定です。
-            </p>
-            <a
-              class="explicit-link"
-              href="https://github.com/iorn121/tabi-no-shiori"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <span class="explicit-link__title">iorn121/tabi-no-shiori</span>
-              <span class="explicit-link__url">https://github.com/iorn121/tabi-no-shiori</span>
-            </a>
-          </section>
-
-          <section>
-            <h3>ColorVerse（カラーバース）</h3>
-            <p>
-              色の学習・ツール・分析・創作をまとめた PWA。カラーピッカー、HEX/RGB/HSL
-              変換、画像の色調補正、JIS 色名参照、カメラ連携、色覚特性シミュレーションなど。React +
-              Vite + TypeScript、Canvas / MediaDevices、i18next による多言語対応です。
-            </p>
-            <a
-              class="explicit-link"
-              href="https://github.com/iorn121/color-verse"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <span class="explicit-link__title">iorn121/color-verse</span>
-              <span class="explicit-link__url">https://github.com/iorn121/color-verse</span>
-            </a>
-            <a
-              class="explicit-link link-item"
-              href="https://color-verse.vercel.app/"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <span class="explicit-link__title">デモ（Vercel）</span>
-              <span class="explicit-link__url">https://color-verse.vercel.app/</span>
-            </a>
-          </section>
-
-          <section>
-            <h3>Shinjuku Chronowalk</h3>
-            <p>
-              新宿区をテーマとした謎解きゲーム。Vite + React + TypeScript + Tailwind、Framer Motion
-              と localforage を使って開発しています。
-            </p>
-            <a
-              class="explicit-link"
-              href="https://github.com/iorn121/shinjuku-chronowalk"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <span class="explicit-link__title">iorn121/shinjuku-chronowalk</span>
-              <span class="explicit-link__url">https://github.com/iorn121/shinjuku-chronowalk</span>
-            </a>
-          </section>
         </section>
 
         <ul class="article-list">
+          <li><a href="./yomu-kamo/">よむかも（Yomu-Kamo）</a></li>
+          <li><a href="./aquasync/">AQUASYNC</a></li>
+          <li><a href="./tabi-no-shiori/">旅の栞（tabi-no-shiori）</a></li>
+          <li><a href="./color-verse/">ColorVerse（カラーバース）</a></li>
+          <li><a href="./shinjuku-chronowalk/">Shinjuku Chronowalk</a></li>
+          <li><a href="./pocket-museum/">Pocket Museum</a></li>
+          <li><a href="./deai/">Deai（であい）</a></li>
+          <li><a href="./quant-ops/">quant-ops</a></li>
+          <li><a href="./rhythm-mile/">Rhythm Mile（リズムマイル）</a></li>
           <!-- kurage:child-links -->
         </ul>
       </div>

--- a/articles/create/programming/pocket-museum/index.html
+++ b/articles/create/programming/pocket-museum/index.html
@@ -1,0 +1,61 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1,shrink-to-fit=no" />
+    <site-head title="Pocket Museum"></site-head>
+    <link rel="stylesheet" href="../../../../css/style.css" />
+  </head>
+  <body>
+    <site-header></site-header>
+
+    <div id="app">
+      <div class="memox memox--page">
+        <header>
+          <h1 class="title">Pocket Museum</h1>
+        </header>
+
+        <section class="section-group">
+          <section>
+            <h3>概要</h3>
+            <p>
+              旅先で出会ったポストカードを、手のひらの中の小さな美術館に。美術館・博物館で買ったポストカードをスマホで取り込み、場所と思い出を添えてコレクション化する個人用
+              PWA です。「静かな美術館をポケットに」を北極星に、最小限の UI
+              と丁寧なマイクロインタラクションを目指しています。
+            </p>
+            <ul class="experience-list">
+              <li><strong>取り込み:</strong> 撮影から矩形検出・台形補正・色補正まで自動化</li>
+              <li><strong>思い出:</strong> 場所・日付・コメントを作品と一緒に保存</li>
+              <li><strong>鑑賞:</strong> フォルダではなくギャラリーとして眺める体験</li>
+            </ul>
+            <p>
+              Vite + React + TypeScript、Tailwind CSS、Framer
+              Motion、Dexie（IndexedDB）、Zustand、React
+              Router、vite-plugin-pwa。クラウドバックアップは Supabase を予定しています。
+            </p>
+          </section>
+
+          <section>
+            <h3>リンク</h3>
+            <a
+              class="explicit-link"
+              href="https://github.com/iorn121/pocket-museum"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <span class="explicit-link__title">iorn121/pocket-museum</span>
+              <span class="explicit-link__url">https://github.com/iorn121/pocket-museum</span>
+            </a>
+          </section>
+        </section>
+
+        <ul class="article-list">
+          <!-- kurage:child-links -->
+        </ul>
+      </div>
+    </div>
+
+    <script type="module" src="/site.js"></script>
+    <site-footer></site-footer>
+  </body>
+</html>

--- a/articles/create/programming/quant-ops/index.html
+++ b/articles/create/programming/quant-ops/index.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1,shrink-to-fit=no" />
+    <site-head title="quant-ops"></site-head>
+    <link rel="stylesheet" href="../../../../css/style.css" />
+  </head>
+  <body>
+    <site-header></site-header>
+
+    <div id="app">
+      <div class="memox memox--page">
+        <header>
+          <h1 class="title">quant-ops</h1>
+        </header>
+
+        <section class="section-group">
+          <section>
+            <h3>概要</h3>
+            <p>
+              長期投資向けの日本株自動スクリーニングシステムです。GitHub Actions
+              で毎営業日に銘柄をスクリーニングし、ROE・PER・PBR などから算出したスコアランキングを
+              <code>data/rankings.json</code> に蓄積します。
+            </p>
+            <p>
+              スコア算式は <code>Score = (ROE × 3) + (10 / PBR) + (50 / PER)</code>（min-max 正規化
+              0〜100 点）を想定した軽量パイプラインです。
+            </p>
+          </section>
+
+          <section>
+            <h3>リンク</h3>
+            <a
+              class="explicit-link"
+              href="https://github.com/iorn121/quant-ops"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <span class="explicit-link__title">iorn121/quant-ops</span>
+              <span class="explicit-link__url">https://github.com/iorn121/quant-ops</span>
+            </a>
+          </section>
+        </section>
+
+        <ul class="article-list">
+          <!-- kurage:child-links -->
+        </ul>
+      </div>
+    </div>
+
+    <script type="module" src="/site.js"></script>
+    <site-footer></site-footer>
+  </body>
+</html>

--- a/articles/create/programming/rhythm-mile/index.html
+++ b/articles/create/programming/rhythm-mile/index.html
@@ -1,0 +1,61 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1,shrink-to-fit=no" />
+    <site-head title="Rhythm Mile（リズムマイル）"></site-head>
+    <link rel="stylesheet" href="../../../../css/style.css" />
+  </head>
+  <body>
+    <site-header></site-header>
+
+    <div id="app">
+      <div class="memox memox--page">
+        <header>
+          <h1 class="title">Rhythm Mile（リズムマイル）</h1>
+        </header>
+
+        <section class="section-group">
+          <section>
+            <h3>概要</h3>
+            <p>
+              ランニングと BPM
+              に基づいた音楽プレイリストを組み合わせたモバイルアプリです。ランナーのペースに合わせて最適な音楽を提供し、より楽しく効果的な運動体験を目指しています。
+            </p>
+            <ul class="experience-list">
+              <li>
+                <strong>ランニング:</strong> GPS による距離・ペース・ルート記録、履歴と目標設定
+              </li>
+              <li><strong>ルート:</strong> 目標距離や勾配を考慮したルート提案（予定）</li>
+              <li><strong>音楽:</strong> BPM とペースに連動したプレイリスト（予定）</li>
+            </ul>
+            <p>
+              フェーズ 1 は Android（Material Design 3）を優先。将来 iOS と PWA
+              への展開を想定しています。
+            </p>
+          </section>
+
+          <section>
+            <h3>リンク</h3>
+            <a
+              class="explicit-link"
+              href="https://github.com/iorn121/rhythm-mile"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <span class="explicit-link__title">iorn121/rhythm-mile</span>
+              <span class="explicit-link__url">https://github.com/iorn121/rhythm-mile</span>
+            </a>
+          </section>
+        </section>
+
+        <ul class="article-list">
+          <!-- kurage:child-links -->
+        </ul>
+      </div>
+    </div>
+
+    <script type="module" src="/site.js"></script>
+    <site-footer></site-footer>
+  </body>
+</html>

--- a/articles/create/programming/shinjuku-chronowalk/index.html
+++ b/articles/create/programming/shinjuku-chronowalk/index.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1,shrink-to-fit=no" />
+    <site-head title="Shinjuku Chronowalk"></site-head>
+    <link rel="stylesheet" href="../../../../css/style.css" />
+  </head>
+  <body>
+    <site-header></site-header>
+
+    <div id="app">
+      <div class="memox memox--page">
+        <header>
+          <h1 class="title">Shinjuku Chronowalk</h1>
+        </header>
+
+        <section class="section-group">
+          <section>
+            <h3>概要</h3>
+            <p>
+              新宿区をテーマとした謎解きゲームです。Vite + React + TypeScript + Tailwind、Framer
+              Motion と localforage を使って開発しています。
+            </p>
+          </section>
+
+          <section>
+            <h3>リンク</h3>
+            <a
+              class="explicit-link"
+              href="https://github.com/iorn121/shinjuku-chronowalk"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <span class="explicit-link__title">iorn121/shinjuku-chronowalk</span>
+              <span class="explicit-link__url">https://github.com/iorn121/shinjuku-chronowalk</span>
+            </a>
+          </section>
+        </section>
+
+        <ul class="article-list">
+          <!-- kurage:child-links -->
+        </ul>
+      </div>
+    </div>
+
+    <script type="module" src="/site.js"></script>
+    <site-footer></site-footer>
+  </body>
+</html>

--- a/articles/create/programming/tabi-no-shiori/index.html
+++ b/articles/create/programming/tabi-no-shiori/index.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1,shrink-to-fit=no" />
+    <site-head title="旅の栞（tabi-no-shiori）"></site-head>
+    <link rel="stylesheet" href="../../../../css/style.css" />
+  </head>
+  <body>
+    <site-header></site-header>
+
+    <div id="app">
+      <div class="memox memox--page">
+        <header>
+          <h1 class="title">旅の栞（tabi-no-shiori）</h1>
+        </header>
+
+        <section class="section-group">
+          <section>
+            <h3>概要</h3>
+            <p>
+              Svelte + Vite
+              ベースのフロントエンド用リポジトリです。リポジトリ名のとおり、旅の記録・しおりとして使う予定で構築中です。
+            </p>
+          </section>
+
+          <section>
+            <h3>リンク</h3>
+            <a
+              class="explicit-link"
+              href="https://github.com/iorn121/tabi-no-shiori"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <span class="explicit-link__title">iorn121/tabi-no-shiori</span>
+              <span class="explicit-link__url">https://github.com/iorn121/tabi-no-shiori</span>
+            </a>
+          </section>
+        </section>
+
+        <ul class="article-list">
+          <!-- kurage:child-links -->
+        </ul>
+      </div>
+    </div>
+
+    <script type="module" src="/site.js"></script>
+    <site-footer></site-footer>
+  </body>
+</html>

--- a/articles/create/programming/yomu-kamo/index.html
+++ b/articles/create/programming/yomu-kamo/index.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1,shrink-to-fit=no" />
+    <site-head title="よむかも（Yomu-Kamo）"></site-head>
+    <link rel="stylesheet" href="../../../../css/style.css" />
+  </head>
+  <body>
+    <site-header></site-header>
+
+    <div id="app">
+      <div class="memox memox--page">
+        <header>
+          <h1 class="title">よむかも（Yomu-Kamo）</h1>
+        </header>
+
+        <section class="section-group">
+          <section>
+            <h3>概要</h3>
+            <p>
+              論文や本を「よむかも」とストックし、後から読み返すためのカジュアルな管理アプリ。 DOI
+              からの取り込み、ISBN・バーコード、AI 要約やタグ付けなどを想定しています。
+            </p>
+            <p>
+              フロントは Next.js（App Router）と TypeScript、バックエンドは Go、データは
+              Supabase。デプロイは Vercel や Cloud Run を想定した構成です。
+            </p>
+          </section>
+
+          <section>
+            <h3>リンク</h3>
+            <a
+              class="explicit-link"
+              href="https://github.com/iorn121/Yomu-Kamo"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <span class="explicit-link__title">iorn121/Yomu-Kamo</span>
+              <span class="explicit-link__url">https://github.com/iorn121/Yomu-Kamo</span>
+            </a>
+          </section>
+        </section>
+
+        <ul class="article-list">
+          <!-- kurage:child-links -->
+        </ul>
+      </div>
+    </div>
+
+    <script type="module" src="/site.js"></script>
+    <site-footer></site-footer>
+  </body>
+</html>

--- a/docs/spec-programming-child-pages.md
+++ b/docs/spec-programming-child-pages.md
@@ -1,0 +1,57 @@
+# 仕様: プログラミング配下に子記事ページを作成
+
+## 背景
+
+`articles/create/programming/index.html` に、メインで進めている複数プロジェクトと言語一覧が1ページにまとまっている。ローカルで整えた内容を `npm run kurage`（`new-page`）の規約に沿って**子記事**として切り出し、親ページからリンクする。
+
+## スコープ
+
+### やること
+
+1. `kurage new-article` で次の9ページを `articles/create/programming/` 配下に作成する。
+   - 追加先: **サブページのみ**（`--add-to subpage`）。トップの `projects.ts` には追加しない。
+   - 親: `programming`（`--parent programming`）
+
+| slug                  | タイトル（親リンク・ページ見出し） |
+| --------------------- | ---------------------------------- |
+| `yomu-kamo`           | よむかも（Yomu-Kamo）              |
+| `aquasync`            | AQUASYNC                           |
+| `tabi-no-shiori`      | 旅の栞（tabi-no-shiori）           |
+| `color-verse`         | ColorVerse（カラーバース）         |
+| `shinjuku-chronowalk` | Shinjuku Chronowalk                |
+| `pocket-museum`       | Pocket Museum                      |
+| `deai`                | Deai（であい）                     |
+| `quant-ops`           | quant-ops                          |
+| `rhythm-mile`         | Rhythm Mile（リズムマイル）        |
+
+2. 各子ページの `index.html` に、現親ページの該当 `<section>` の本文（説明・`explicit-link`）を移す。新規 4 件は各リポジトリの README を要約して記載する。
+3. 親 `programming/index.html` を整理する。
+   - 残す: GitHub リンク、主に書いている言語、子ページ一覧（`kurage` が `<!-- kurage:child-links -->` に `<li>` を挿入）
+   - 削除: 各プロジェクトの詳細セクション（子ページへ移動）
+
+### 非スコープ
+
+- トップカード（`src/projects.ts`）の追加・変更
+- 新規 npm 依存の追加
+- サムネイル画像の追加
+- README の再取得（既存本文をそのまま移す）
+
+## 影響ファイル
+
+- `articles/create/programming/index.html`（編集）
+- `articles/create/programming/{slug}/index.html`（新規 ×5）
+- `tools/kurage.js` / テンプレート（変更なし・CLI 実行のみ）
+
+## 検証
+
+```bash
+npm run lint
+npm run build
+```
+
+ローカルで `npm run dev` し、親ページの子リンク一覧と各子ページの表示・CSS パスを確認する。
+
+## 前提・確認事項
+
+- 分割対象は上記5プロジェクトのみでよいか。
+- slug・タイトル表の変更希望があれば承認前に指示すること。


### PR DESCRIPTION
## Summary

- `articles/create/programming/` をハブ化し、各プロジェクトを子記事（9件）として `kurage` で作成
- 既存5件（Yomu-Kamo, AQUASYNC, tabi-no-shiori, color-verse, shinjuku-chronowalk）は親ページから本文を移行
- 新規4件（pocket-museum, deai, quant-ops, rhythm-mile）は各 GitHub リポジトリの README を要約して追加
- 仕様メモ: `docs/spec-programming-child-pages.md`

## Test plan

- [x] `npm run lint`
- [x] `npm run build`
- [ ] `npm run dev` で `/articles/create/programming/` の子リンク一覧と各子ページの表示を確認


Made with [Cursor](https://cursor.com)